### PR TITLE
Fixing #2 and #3

### DIFF
--- a/src/exo4jax/_src/proto.py
+++ b/src/exo4jax/_src/proto.py
@@ -6,6 +6,10 @@ from exo4jax._src.types import Array
 
 class LightCurveBody(Protocol):
     @property
+    def shape(self) -> Tuple[int, ...]:
+        ...
+
+    @property
     def radius(self) -> Array:
         ...
 

--- a/src/exo4jax/_src/transit.py
+++ b/src/exo4jax/_src/transit.py
@@ -14,6 +14,10 @@ class TransitOrbit(NamedTuple):
     impact_param: Array
     radius: Array
 
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return self.period.shape
+
     @classmethod
     def init(
         cls,

--- a/src/exo4jax/_src/types.py
+++ b/src/exo4jax/_src/types.py
@@ -1,4 +1,5 @@
 from typing import Any
 
+Scalar = Any
 Array = Any
 PyTree = Any

--- a/src/exo4jax/test_utils.py
+++ b/src/exo4jax/test_utils.py
@@ -1,9 +1,12 @@
-from functools import partial
-
 import jax
+import jax.numpy as jnp
 import numpy as np
 
-assert_allclose = partial(
-    np.testing.assert_allclose,
-    atol=2e-5 if jax.config.jax_enable_x64 else 2e-4,
-)
+
+def assert_allclose(calculated, expected, *args, **kwargs):
+    dtype = jnp.result_type(calculated, expected)
+    if dtype == jnp.float64:
+        kwargs["atol"] = kwargs.get("atol", 2e-5)
+    else:
+        kwargs["atol"] = kwargs.get("atol", 2e-2)
+    np.testing.assert_allclose(calculated, expected, *args, **kwargs)

--- a/src/exo4jax/test_utils.py
+++ b/src/exo4jax/test_utils.py
@@ -1,0 +1,9 @@
+from functools import partial
+
+import jax
+import numpy as np
+
+assert_allclose = partial(
+    np.testing.assert_allclose,
+    atol=2e-5 if jax.config.jax_enable_x64 else 2e-4,
+)

--- a/tests/keplerian_test.py
+++ b/tests/keplerian_test.py
@@ -1,0 +1,13 @@
+import jax.numpy as jnp
+from exo4jax import orbits
+
+
+def test_keplerian_central_shape():
+    assert orbits.KeplerianCentral.init(mass=0.98, radius=0.93).shape == ()
+
+
+def test_casting_dtype():
+    orbit = orbits.KeplerianBody.init(period=1)
+    assert (
+        orbit.period.dtype == jnp.float32 or orbit.period.dtype == jnp.float64
+    )

--- a/tests/light_curves_test.py
+++ b/tests/light_curves_test.py
@@ -1,0 +1,40 @@
+import jax.numpy as jnp
+
+from exo4jax import light_curves, orbits
+from exo4jax.test_utils import assert_allclose
+
+
+def test_keplerian_basic():
+    t = jnp.linspace(-1.0, 10.0, 1000)
+
+    mstar = 0.98
+    rstar = 0.93
+    ld = [0.1, 0.3]
+
+    time_transit = jnp.array([0.0, 0.5])
+    period = jnp.array([1, 4.5])
+    b = jnp.array([0.5, 0.2])
+    r = jnp.array([0.1, 0.3])
+
+    host_star = orbits.KeplerianCentral.init(mass=mstar, radius=rstar)
+    orbit_both = orbits.KeplerianOrbit.init(
+        central=host_star,
+        time_transit=time_transit,
+        period=period,
+        impact_param=b,
+        radius=r,
+    )
+    lc_both = light_curves.QuadLightCurve(ld[0], ld[1]).light_curve(
+        orbit_both, t
+    )
+
+    for n in range(2):
+        orbit = orbits.KeplerianBody.init(
+            central=host_star,
+            time_transit=time_transit[n],
+            period=period[n],
+            impact_param=b[n],
+            radius=r[n],
+        )
+        lc = light_curves.QuadLightCurve(ld[0], ld[1]).light_curve(orbit, t)
+        assert_allclose(lc, lc_both[n])

--- a/tests/orbits_test.py
+++ b/tests/orbits_test.py
@@ -8,11 +8,7 @@ import numpy as np
 import pytest
 
 from exo4jax.orbits import KeplerianBody, KeplerianCentral, KeplerianOrbit
-
-assert_allclose = partial(
-    np.testing.assert_allclose,
-    atol=2e-5 if jax.config.jax_enable_x64 else 2e-4,
-)
+from exo4jax.test_utils import assert_allclose
 
 
 def test_sky_coords():


### PR DESCRIPTION
This fixes the issues with `vmap` dimensions and `dtype`s reported by @catrionamurray in #2 and #3.

There are some questions about how to best define the interface for multi-planet systems. Right now, the `light_curve` function explicitly handles this:

https://github.com/exoplanet-dev/exo4jax/blob/49169bf117d71f92ab633771a928c4543d7d41a3/src/exo4jax/_src/light_curves.py#L88-L93

But that feels a bit brittle.

We should also port these fixes to the `TransitOrbit` since we'll have the same issues there.

Closes #2 
Closes #3